### PR TITLE
Make Facebook interstitials expire after 59 minutes if not shown

### DIFF
--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/MoPubErrorCode.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/MoPubErrorCode.java
@@ -9,7 +9,7 @@ public enum MoPubErrorCode {
     NO_CONNECTION("No internet connection detected."),
 
     /** see {@link com.mopub.common.Constants#AD_EXPIRATION_DELAY } */
-    EXPIRED("Ad expired since it was not shown within 4 hours."),
+    EXPIRED("Ad expired since it was not shown within the time limit."),
 
     ADAPTER_NOT_FOUND("Unable to find Native Network or Custom Event adapter."),
     ADAPTER_CONFIGURATION_ERROR("Native Network or Custom Event adapter was configured incorrectly."),


### PR DESCRIPTION
This is per the requirement "Any ads shown after 60 minutes will not be considered for revenue generation purposes." stated at the web page https://www.facebook.com/audiencenetwork/news-and-insights/required-changes-for-audience-network-publishers